### PR TITLE
chore: add buffer issue repro configs (10430, 10895, 11039, 11072, 12069, 20228)

### DIFF
--- a/issues/10430/config.toml
+++ b/issues/10430/config.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-10430"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/10430/create-clean-data-directories.sh
+++ b/issues/10430/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-10430
+mkdir -p /tmp/vector/github-10430

--- a/issues/10430/five-lines
+++ b/issues/10430/five-lines
@@ -1,0 +1,5 @@
+line one, woohoo
+line two, yippeee
+line three, oh my
+line four, woooooow
+live five, phew, that was a lot

--- a/issues/10430/steps.md
+++ b/issues/10430/steps.md
@@ -1,0 +1,54 @@
+## Fix
+
+Add logic to `buffers::disk::open` which checks for the "old style" vs "new style" buffer data
+directories for the given buffer ID, and either renames the old-style path to the new-style path if
+the new-style path doesn't already exist, or emits a warning if both exist and there is data left in
+the old-style buffer.  If there is no data left, then we rename the old-style directory by appending
+`_old` to it, which stops the logic from seeing it the next time, but leaves it around in case
+something about the code to read the buffer size is wrong and there _is_ still data left.
+
+## Testing Plan
+
+Start by grabbing Vector binaries for 0.18.1, 0.19.0, and build one from the fix branch.  We'll use
+a simple configuration that will read records from stdin and attempt to send them to an HTTP sink.
+
+For the HTTP sink, we'll simply set it to a nonexistent endpoint.  Since Vector will retry
+"connection refused" errors, and retry them infinitely, the messages will never be acknowledged,
+which ensures they remain in the buffer.  For the purposes of verifying that the same data that went
+in is still present after renaming the data directory, etc, we can use `netcat` to listen on the
+port and inspect the HTTP request made by the sink.
+
+## Test Cases
+
+1. Ensure that the new-style directory stays untouched between 0.19.0 and the fix binary:
+    - Run both the 0.19.0 binary and the fix binary with a clean data directory, and ensure they
+      both generate the same data directory.
+2. Ensure that the old-style buffer data directory gets migrated when there's no new-style buffer
+  data directory and the old-style buffer has no data:
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+      data directory, but don't send any data through.
+    - Run the fix binary and ensure that it renames the old-style buffer data directory to the
+      new-style buffer data directory.  Again, send no data through.
+3. Ensure that the old-style buffer data directory gets migrated when there's no new-style buffer
+  data directory and the old-style buffer has data:
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+      data directory, and send a few records through.
+    - Run the fix binary and ensure that it renames the old-style buffer data directory to the
+      new-style buffer data directory.
+4. Ensure that old-style buffer data directory is left as-is when there is still data in it and the
+  new-style buffer data directory exists:
+    - Run the fix binary with a clean data directory and ensure that it creates the new-style buffer
+      data directory, but don't send any data through.
+    - Run the 0.18.1 binary and ensure it creates the old-style buffer data directory, and send a
+      few records into it.
+    - Run the fix binary and ensure that it leaves the old-style buffer data directory as-is, but
+      that it emits a log message, at the warn level, indicating the situation, including the count
+      of records still in the old-style buffer.
+5. Ensure that old-style buffer data directory is moved to the side when there is no data in it and
+  the new-style buffer data directory exists:
+    - Run the fix binary with a clean data directory and ensure that it creates the new-style buffer
+      data directory, but don't send any data through.
+    - Run the 0.18.1 binary and ensure it creates the old-style buffer data directory, but don't
+      send any data through.
+    - Run the fix binary and ensure that it renames the old-style buffer data directory with the
+      `_old` prefix, and that it emits no log message.

--- a/issues/10430/test-results.md
+++ b/issues/10430/test-results.md
@@ -1,0 +1,289 @@
+## Test Results
+
+### Test 1
+
+```shell
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-v0.19.0 -c config.toml
+2022-01-12T20:32:03.681166Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-12T20:32:03.681208Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-12T20:32:03.681884Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-12T20:32:03.714053Z  INFO vector::topology::running: Running healthchecks.
+2022-01-12T20:32:03.714081Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-12T20:32:03.714110Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-12T20:32:03.714105Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-12T20:32:03.714146Z  INFO vector: Vector has started. debug="false" version="0.19.0" arch="x86_64" build_id="da60b55 2021-12-28"
+2022-01-12T20:32:03.714157Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-12T20:32:06.890404Z  INFO vector: Vector has stopped.
+2022-01-12T20:32:06.890480Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-12T20:32:06.891601Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 15:32 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-12T20:32:22.317908Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-12T20:32:22.317956Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-12T20:32:22.318771Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-12T20:32:22.351782Z  INFO vector::topology::running: Running healthchecks.
+2022-01-12T20:32:22.351831Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-12T20:32:22.351840Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-12T20:32:22.351863Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-12T20:32:22.351894Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+2022-01-12T20:32:22.351905Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-12T20:32:23.959065Z  INFO vector: Vector has stopped.
+2022-01-12T20:32:23.959111Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-12T20:32:23.960238Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 15:32 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$
+```
+
+### Test 2
+
+```shell
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-v0.18.1 -c config.toml
+2022-01-12T20:33:39.848991Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-12T20:33:39.849036Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-12T20:33:39.850934Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-12T20:33:39.883507Z  INFO vector::topology::running: Running healthchecks.
+2022-01-12T20:33:39.883536Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-12T20:33:39.883568Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-12T20:33:39.883564Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-12T20:33:39.883609Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-12T20:33:39.883618Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-12T20:33:43.701580Z  INFO vector: Vector has stopped.
+2022-01-12T20:33:43.701645Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-12T20:33:43.702750Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 15:33 http_tarpit_buffer
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/http_tarpit_buffer/
+total 16
+-rw-r--r-- 1 toby toby   0 Jan 12 15:33 000005.log
+-rw-r--r-- 1 toby toby  16 Jan 12 15:33 CURRENT
+-rw-r--r-- 1 toby toby   0 Jan 12 15:33 LOCK
+-rw-rw-r-- 1 toby toby 181 Jan 12 15:33 LOG
+-rw-rw-r-- 1 toby toby  60 Jan 12 15:33 LOG.old
+-rw-r--r-- 1 toby toby  50 Jan 12 15:33 MANIFEST-000004
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-12T20:34:12.682402Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-12T20:34:12.682456Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-12T20:34:12.683278Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-12T20:34:12.716426Z  INFO vector::topology::running: Running healthchecks.
+2022-01-12T20:34:12.716465Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-12T20:34:12.716486Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-12T20:34:12.716485Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-12T20:34:12.716517Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+2022-01-12T20:34:12.716530Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-12T20:34:15.058151Z  INFO vector: Vector has stopped.
+2022-01-12T20:34:15.058233Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-12T20:34:15.059404Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 15:34 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/http_tarpit_id/
+total 16
+-rw-r--r-- 1 toby toby   0 Jan 12 15:34 000009.log
+-rw-r--r-- 1 toby toby  16 Jan 12 15:34 CURRENT
+-rw-r--r-- 1 toby toby   0 Jan 12 15:33 LOCK
+-rw-rw-r-- 1 toby toby 181 Jan 12 15:34 LOG
+-rw-rw-r-- 1 toby toby 181 Jan 12 15:34 LOG.old
+-rw-r--r-- 1 toby toby  50 Jan 12 15:34 MANIFEST-000008
+toby@consigliere:~/src/vector/bugs/github-10430$
+```
+
+### Test 3
+
+```shell
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ cat five-lines | ./vector-v0.18.1 -c config.toml
+2022-01-13T02:26:45.125553Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-13T02:26:45.125598Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:26:45.127484Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:26:45.153710Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:26:45.153742Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:26:45.153777Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:26:45.153773Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:26:45.153813Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-13T02:26:45.153823Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-01-13T02:26:45.153889Z  INFO vector::shutdown: All sources have finished.
+2022-01-13T02:26:45.153892Z  INFO vector: Vector has stopped.
+2022-01-13T02:26:45.153893Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:26:45.154895Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-01-13T02:26:46.155677Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-13T02:26:47.156971Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-13T02:26:48.158228Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-13T02:26:48.544843Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:26 http_tarpit_buffer
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-13T02:27:07.943754Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-13T02:27:07.943797Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:27:07.944311Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:27:07.944328Z  INFO buffers::disk: Migrated old buffer data directory from '/tmp/vector/github-10430/http_tarpit_buffer' to '/tmp/vector/github-10430/http_tarpit_id' for 'http_tarpit' sink.
+2022-01-13T02:27:07.976821Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:27:07.976842Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:27:07.976852Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:27:07.976865Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:27:07.976894Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+2022-01-13T02:27:08.978664Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-13T02:27:09.979975Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-13T02:27:10.628838Z  INFO vector: Vector has stopped.
+2022-01-13T02:27:10.628900Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:27:10.630025Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-01-13T02:27:10.981790Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-13T02:27:12.522956Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:27 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$
+
+# Output from netcat if we run `vector-fix` a second time while there's something listening.
+# This shows the messages actually making it out of the buffer after renaming the directory.
+POST /foo HTTP/1.1
+content-type: application/x-ndjson
+user-agent: Vector/0.20.0 (x86_64-unknown-linux-gnu)
+accept-encoding: identity
+host: localhost:7777
+content-length: 615
+
+{"host":"consigliere","message":"line one, woohoo","source_type":"stdin","timestamp":"2022-01-12T20:36:57.451273579Z"}
+{"host":"consigliere","message":"line two, yippeee","source_type":"stdin","timestamp":"2022-01-12T20:36:57.451286459Z"}
+{"host":"consigliere","message":"line three, oh my","source_type":"stdin","timestamp":"2022-01-12T20:36:57.451291089Z"}
+{"host":"consigliere","message":"line four, woooooow","source_type":"stdin","timestamp":"2022-01-12T20:36:57.451294469Z"}
+{"host":"consigliere","message":"live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-01-12T20:36:57.451298419Z"}
+```
+
+### Test 4
+
+```shell
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-13T02:30:09.627541Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-13T02:30:09.627589Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:30:09.628111Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:30:09.660834Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:30:09.660859Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:30:09.660870Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:30:09.660881Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:30:09.660906Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-13T02:30:10.829960Z  INFO vector: Vector has stopped.
+2022-01-13T02:30:10.830030Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:30:10.831161Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:30 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ cat five-lines | ./vector-v0.18.1 -c config.toml
+2022-01-13T02:30:20.909087Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-13T02:30:20.909134Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:30:20.911037Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:30:20.943567Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:30:20.943602Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:30:20.943615Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:30:20.943627Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:30:20.943658Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-13T02:30:20.943667Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-01-13T02:30:20.943700Z  INFO vector::shutdown: All sources have finished.
+2022-01-13T02:30:20.943704Z  INFO vector: Vector has stopped.
+2022-01-13T02:30:20.943701Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:30:20.944743Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-01-13T02:30:21.945480Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-13T02:30:22.946740Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-13T02:30:23.289145Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 8
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:30 http_tarpit_buffer
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:30 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-13T02:30:33.136334Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-13T02:30:33.136376Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:30:33.136891Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:30:33.153853Z  WARN buffers::disk: Found both old and new buffers with data for 'http_tarpit' sink. This may indicate that you upgraded to 0.19.x prior to a regression being fixed which deals with disk buffer directory names. Using new buffers and ignoring old. See https://github.com/vectordotdev/vector/issues/10430 for more information.
+
+You can suppress this message by renaming the old buffer data directory to something else.  Current path for old buffer data directory: /tmp/vector/github-10430/http_tarpit_buffer, suggested path for renaming: /tmp/vector/github-10430/http_tarpit_buffer_old old_buffer_record_count=5 old_buffer_size=565
+2022-01-13T02:30:33.177038Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:30:33.177058Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:30:33.177080Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:30:33.177079Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:30:33.177103Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-13T02:30:35.531084Z  INFO vector: Vector has stopped.
+2022-01-13T02:30:35.531145Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:30:35.532265Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 8
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:30 http_tarpit_buffer
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:30 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$
+```
+
+### Test 5
+
+```shell
+toby@consigliere:~/src/vector/bugs/github-10430$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 0
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-13T02:32:58.303181Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-13T02:32:58.303215Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:32:58.303763Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:32:58.336135Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:32:58.336157Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:32:58.336187Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:32:58.336182Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:32:58.336211Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-13T02:32:59.845171Z  INFO vector: Vector has stopped.
+2022-01-13T02:32:59.845227Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit, stdin" time_remaining="59 seconds left"
+2022-01-13T02:32:59.845222Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:32 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-v0.18.1 -c config.toml
+2022-01-13T02:33:16.321126Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-13T02:33:16.321171Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:33:16.323128Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:33:16.355748Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:33:16.355778Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:33:16.355809Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:33:16.355806Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:33:16.355850Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-13T02:33:16.355860Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-13T02:33:18.543378Z  INFO vector: Vector has stopped.
+2022-01-13T02:33:18.543427Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:33:18.544521Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 8
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:33 http_tarpit_buffer
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:32 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$ ./vector-fix -c config.toml
+2022-01-13T02:33:23.465565Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-13T02:33:23.465605Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-13T02:33:23.466142Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-13T02:33:23.480721Z  INFO buffers::disk: Archived old buffer data directory from '/tmp/vector/github-10430/http_tarpit_buffer' to '/tmp/vector/github-10430/http_tarpit_buffer_old' for 'http_tarpit' sink.
+2022-01-13T02:33:23.503920Z  INFO vector::topology::running: Running healthchecks.
+2022-01-13T02:33:23.503939Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-13T02:33:23.503956Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-13T02:33:23.503962Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-13T02:33:23.504032Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-13T02:33:25.593636Z  INFO vector: Vector has stopped.
+2022-01-13T02:33:25.593691Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-13T02:33:25.594791Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/bugs/github-10430$ ls -l /tmp/vector/github-10430/
+total 8
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:33 http_tarpit_buffer_old
+drwxr-xr-x 2 toby toby 4096 Jan 12 21:33 http_tarpit_id
+toby@consigliere:~/src/vector/bugs/github-10430$
+```

--- a/issues/10895/config.toml
+++ b/issues/10895/config.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-10895"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/10895/create-clean-data-directories.sh
+++ b/issues/10895/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-10895
+mkdir -p /tmp/vector/github-10895

--- a/issues/10895/get-and-build-vector-binaries.sh
+++ b/issues/10895/get-and-build-vector-binaries.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+curl -q -o vector-v0.18.1.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.18.1/vector-0.18.1-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.18.1.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.18.1
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.18.1.tar.gz
+
+curl -q -o vector-v0.19.1.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.19.1/vector-0.19.1-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.19.1.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.19.1
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.19.1.tar.gz
+
+pushd ../..
+cargo clean && cargo build --release --no-default-features --features sources-stdin,sinks-http
+popd || exit
+cp ../../target/release/vector vector-pr

--- a/issues/10895/steps.md
+++ b/issues/10895/steps.md
@@ -1,0 +1,38 @@
+## Enhancement
+
+As part of the fallout of #10379, we wanted to further shore up our testing around buffers to
+ideally prevent us (me) for inadvertently changing things and not noticing... like the buffer data
+directory.
+
+To that end, the PR to address #10895 is simple, but we're doing our due diligence here by
+re-running tests that are more or less identical to what we did for #10430, so that we can feel
+confident that our changes here haven't yet again introduced a regression.
+
+## Testing Plan
+
+Start by grabbing Vector binaries for 0.18.1 and 0.19.1, and build one from the PR branch.  We'll
+use the same configuration as the testing for #10430, which is a stdin source and HTTP sink,
+although we won't actually _use_ them.  In this case, we just need a valid configuration that will
+also create a buffer.
+
+## Test Case(s)
+
+1. Establish a baseline of the "old to new" migration behavior from 0.18.1 to 0.19.1:
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    data directory, but don't send any data through.
+    - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    new-style buffer data directory.  Again, send no data through.
+    - No other data directories for the buffer should exist.
+2. Ensure that the "old to new" migration logic still works from 0.18.1 (old) to the PR (new) version:
+    - Run the 0.18.1 binary with a clean data directory and ensure it creates the old-style buffer
+    data directory, but don't send any data through.
+    - Run the PR binary and ensure that it renames the old-style buffer data directory to the
+    new-style buffer data directory.  Again, send no data through.
+    - No other data directories for the buffer should exist.
+    - Crucially, each step should appear identical to the output in test case #1.
+3. Ensure that the "new" style name still holds through from 0.19.1 to the PR version:
+    - Run the 0.19.1 binary with a clean data directory and ensure it creates the new-style buffer
+    data directory, but don't send any data through.
+    - Run the PR binary and ensure that it leaves the data directory, as created by the 0.19.1 binary,
+    as is, in terms of naming.
+    - No other data directories for the buffer should exist.

--- a/issues/10895/test-results.md
+++ b/issues/10895/test-results.md
@@ -1,0 +1,124 @@
+## Test Results
+
+### Test 1
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.18.1 --config config.toml
+2022-01-26T22:20:16.979995Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-26T22:20:16.980039Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:16.981919Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:17.010091Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:17.010121Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:17.010157Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:17.010155Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:20:17.010203Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-26T22:20:17.010213Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:20:17.627876Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:17.627922Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:17.627952Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="stdin, http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_buffer
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.19.1 --config config.toml
+2022-01-26T22:20:28.399808Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:20:28.399854Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:28.400532Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:28.400543Z  INFO buffers::disk: Migrated old buffer data directory from '/tmp/vector/github-10895/http_tarpit_buffer' to '/tmp/vector/github-10895/http_tarpit_id' for 'http_tarpit' sink.
+2022-01-26T22:20:28.430796Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:28.430824Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:28.430847Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:28.430849Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:20:28.430879Z  INFO vector: Vector has started. debug="false" version="0.19.1" arch="x86_64" build_id="3cf70cf 2022-01-25"
+2022-01-26T22:20:28.430891Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:20:29.294516Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:29.294605Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:29.295668Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```
+
+### Test 2
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.18.1 --config config.toml
+2022-01-26T22:20:57.412384Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info"
+2022-01-26T22:20:57.412428Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:20:57.414343Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:20:57.447157Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:20:57.447189Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:20:57.447211Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:20:57.447245Z  INFO vector: Vector has started. debug="false" version="0.18.1" arch="x86_64" build_id="c4adb60 2021-11-30"
+2022-01-26T22:20:57.447255Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-01-26T22:20:57.447245Z  INFO vector::topology::builder: Healthcheck: Passed.
+^C2022-01-26T22:20:58.292801Z  INFO vector: Vector has stopped.
+2022-01-26T22:20:58.292844Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:20:58.293936Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:20 http_tarpit_buffer
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-pr --config config.toml
+2022-01-26T22:21:06.698724Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:06.698761Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:06.699272Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:06.699295Z  INFO vector_buffers::disk: Migrated old buffer data directory from '/tmp/vector/github-10895/http_tarpit_buffer' to '/tmp/vector/github-10895/http_tarpit_id' for 'http_tarpit' sink.
+2022-01-26T22:21:06.728976Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:06.728997Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:06.729017Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:06.729027Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:06.729060Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-26T22:21:07.388780Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:07.388822Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:07.389894Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```
+
+### Test 3
+
+```shell
+toby@consigliere:~/src/vector/testing/github-10895$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 0
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-v0.19.1 --config config.toml
+2022-01-26T22:21:41.620286Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:41.620331Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:41.621069Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:41.653647Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:41.653675Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:41.653688Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:41.653697Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:41.653726Z  INFO vector: Vector has started. debug="false" version="0.19.1" arch="x86_64" build_id="3cf70cf 2022-01-25"
+2022-01-26T22:21:41.653737Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+^C2022-01-26T22:21:42.482989Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:42.483035Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:42.484107Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$ ./vector-pr --config config.toml
+2022-01-26T22:21:53.367043Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T22:21:53.367080Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T22:21:53.367588Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T22:21:53.397431Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T22:21:53.397453Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T22:21:53.397473Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T22:21:53.397480Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T22:21:53.397517Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+^C2022-01-26T22:21:54.469681Z  INFO vector: Vector has stopped.
+2022-01-26T22:21:54.469727Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T22:21:54.470832Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-10895$ ls -l /tmp/vector/github-10895
+total 4
+drwxr-xr-x 2 toby toby 4096 Jan 26 17:21 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-10895$
+```

--- a/issues/11039/config.toml
+++ b/issues/11039/config.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-11039"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/11039/create-clean-data-directories.sh
+++ b/issues/11039/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-11039
+mkdir -p /tmp/vector/github-11039

--- a/issues/11039/five-lines
+++ b/issues/11039/five-lines
@@ -1,0 +1,5 @@
+line one, woohoo
+line two, yippeee
+line three, oh my
+line four, woooooow
+live five, phew, that was a lot

--- a/issues/11039/get-and-build-vector-binaries.sh
+++ b/issues/11039/get-and-build-vector-binaries.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+curl -q -o vector-v0.19.0.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.19.0/vector-0.19.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.19.0.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.19.0
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.19.0.tar.gz
+
+pushd ../..
+cargo clean && cargo build --release --no-default-features --features sources-stdin,sinks-http
+popd || exit
+cp ../../target/release/vector vector-pr

--- a/issues/11039/steps.md
+++ b/issues/11039/steps.md
@@ -1,0 +1,32 @@
+## Enhancement
+
+Add support to disk buffers to allow for versioning/schema evolution in the future, such that new
+versions of Vector can buffer items using different codecs or event schemas, while still potentially
+supporting previous versions during deprecation periods.
+
+This primarily changes disk buffer v2 code, which is not yet officially released, so we're cool with
+the breaking change there.  This testing focuses on the changes to disk buffer v1, which as designed
+should be a no-op, but to avoid data loss and another #10430-esque issue... we want to explicitly
+test before merging.
+
+## Testing Plan
+
+Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch.  We'll use
+a simple configuration that will read records from stdin and attempt to send them to an HTTP sink.
+
+For the HTTP sink, we'll simply set it to a nonexistent endpoint.  Since Vector will retry
+"connection refused" errors, and retry them infinitely, the messages will never be acknowledged,
+which ensures they remain in the buffer.  For the purposes of verifying that the same data that went
+in is still present after renaming the data directory, etc, we can use `netcat` (binary is called
+`nc`) to listen on the port and inspect the HTTP request made by the sink.
+
+## Test Case(s)
+
+1. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
+   be read back from a version of Vector _with_ this change:
+   - Start the test without `nc` listening on the HTTP port.
+   - Run the 0.19.0 binary with a clean data directory and send a few records through.
+   - Stop Vector.
+   - Start `nc` listening on the relevant port.
+   - Run the PR binary and ensure that it reads the records from the buffer and sends them to the
+     HTTP sink.

--- a/issues/11039/test-results.md
+++ b/issues/11039/test-results.md
@@ -1,0 +1,78 @@
+## Test Results
+
+### Test 1
+
+```shell
+toby@consigliere:~/src/vector/testing/github-11039$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-11039$ cat five-lines
+line one, woohoo
+line two, yippeee
+line three, oh my
+line four, woooooow
+live five, phew, that was a lot
+toby@consigliere:~/src/vector/testing/github-11039$ cat five-lines | ./vector-v0.19.0 --config config.toml
+2022-01-26T19:16:16.785776Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T19:16:16.785818Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T19:16:16.786515Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T19:16:16.815793Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T19:16:16.815824Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T19:16:16.815836Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T19:16:16.815846Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T19:16:16.815876Z  INFO vector: Vector has started. debug="false" version="0.19.0" arch="x86_64" build_id="da60b55 2021-12-28"
+2022-01-26T19:16:16.815886Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-01-26T19:16:16.815939Z  INFO vector::shutdown: All sources have finished.
+2022-01-26T19:16:16.815946Z  INFO vector: Vector has stopped.
+2022-01-26T19:16:16.815944Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T19:16:16.817024Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-01-26T19:16:17.817876Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-26T19:16:18.819194Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-26T19:16:19.820532Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-26T19:16:20.105954Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-11039$ ls -l /tmp/vector/github-11039/http_tarpit_id/
+total 20
+-rw-r--r-- 1 toby toby 639 Jan 26 14:16 000005.log
+-rw-r--r-- 1 toby toby  16 Jan 26 14:16 CURRENT
+-rw-r--r-- 1 toby toby   0 Jan 26 14:16 LOCK
+-rw-rw-r-- 1 toby toby 181 Jan 26 14:16 LOG
+-rw-rw-r-- 1 toby toby  60 Jan 26 14:16 LOG.old
+-rw-r--r-- 1 toby toby  50 Jan 26 14:16 MANIFEST-000004
+
+# In another window, we run `nc -l -k -p 7777` which runs netcat in listen mode on port 7777, TCP, on all interfaces.
+
+toby@consigliere:~/src/vector/testing/github-11039$ ./vector-pr --config config.toml
+2022-01-26T19:17:06.436364Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-01-26T19:17:06.436404Z  INFO vector::app: Loading configs. paths=["config.toml"]
+2022-01-26T19:17:06.436926Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-01-26T19:17:06.470017Z  INFO vector::topology::running: Running healthchecks.
+2022-01-26T19:17:06.470039Z  INFO vector::topology::running: Starting source. key=stdin
+2022-01-26T19:17:06.470059Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-01-26T19:17:06.470057Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-01-26T19:17:06.470084Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="none"
+
+# Vector is waiting here for netcat to respond, which it never will, so we Ctrl-C on Vector, which then still has it waiting for netcat to respond, hence the "waiting on running component" log messages, and then we also Ctrl-C netcat which causes the retries, and we do another Ctrl-C to forcefully stop Vector.
+
+^C2022-01-26T19:17:15.674107Z  INFO vector: Vector has stopped.
+2022-01-26T19:17:15.674177Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-01-26T19:17:15.675245Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-01-26T19:17:20.674746Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="54 seconds left"
+2022-01-26T19:17:22.625121Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: connection closed before message completed
+2022-01-26T19:17:23.626436Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-01-26T19:17:24.627805Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-01-26T19:17:25.572097Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-11039$
+
+# Output from netcat after running `vector-pr`:
+
+POST /foo HTTP/1.1
+content-type: application/x-ndjson
+user-agent: Vector/0.20.0 (x86_64-unknown-linux-gnu)
+accept-encoding: identity
+host: localhost:7777
+content-length: 615
+
+{"host":"consigliere","message":"line one, woohoo","source_type":"stdin","timestamp":"2022-01-26T19:16:16.815899465Z"}
+{"host":"consigliere","message":"line two, yippeee","source_type":"stdin","timestamp":"2022-01-26T19:16:16.815909555Z"}
+{"host":"consigliere","message":"line three, oh my","source_type":"stdin","timestamp":"2022-01-26T19:16:16.815912815Z"}
+{"host":"consigliere","message":"line four, woooooow","source_type":"stdin","timestamp":"2022-01-26T19:16:16.815917085Z"}
+{"host":"consigliere","message":"live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-01-26T19:16:16.815920305Z"}
+```

--- a/issues/11072/config-right-http.toml
+++ b/issues/11072/config-right-http.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-11072"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/11072/config-wrong-http.toml
+++ b/issues/11072/config-wrong-http.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-11072"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7778/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/11072/create-clean-data-directories.sh
+++ b/issues/11072/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-11072
+mkdir -p /tmp/vector/github-11072

--- a/issues/11072/five-lines-first
+++ b/issues/11072/five-lines-first
@@ -1,0 +1,5 @@
+ONE line one, woohoo
+ONE line two, yippeee
+ONE line three, oh my
+ONE line four, woooooow
+ONE live five, phew, that was a lot

--- a/issues/11072/five-lines-second
+++ b/issues/11072/five-lines-second
@@ -1,0 +1,5 @@
+TWO line one, woohoo
+TWO line two, yippeee
+TWO line three, oh my
+TWO line four, woooooow
+TWO live five, phew, that was a lot

--- a/issues/11072/get-and-build-vector-binaries.sh
+++ b/issues/11072/get-and-build-vector-binaries.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+curl -q -o vector-v0.19.0.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.19.0/vector-0.19.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.19.0.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.19.0
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.19.0.tar.gz
+
+pushd ../..
+cargo clean && cargo build --release --no-default-features --features sources-stdin,sinks-http
+popd || exit
+cp ../../target/release/vector vector-pr

--- a/issues/11072/steps.md
+++ b/issues/11072/steps.md
@@ -1,0 +1,50 @@
+# Testing Plan - Send arrays of events through the topology (#11072)
+
+## Context
+
+As this PR introduces `EventArray`, it represents a change to the type flowing through buffers.  In
+order to prevent a backwards-incompatible change, this PR adds a change that allows the encoding
+scheme to try to decode as either `EventArray` or `Event` in order to be able to load older buffer
+files and continue processing them while using `EventArray` going forward.
+
+This test ensures that we can write `Event`s to the buffer, and then read them out when using the
+newer code.
+
+## Plan
+
+Start by grabbing a Vector binary for 0.19.0, and build one from the PR branch.  We'll use a simple
+configuration that will read records from stdin and attempt to send them to an HTTP sink.
+
+For the HTTP sink, we'll have one configuration that uses an invalid port and another, an identical
+version, which has the correct port. Since Vector will retry "connection refused" errors, and retry
+them infinitely, the messages will never be acknowledged, which ensures they remain in the buffer.
+For the purposes of verifying that the same data that went in is still present after renaming the
+data directory, etc, we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
+endpoint that can be configured to respond a certain way) to listen on the port and inspect the HTTP
+request made by the sink.
+
+## Test Case(s)
+
+1. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
+   be read back from a version of Vector _with_ this change:
+   - Start `dummyhttp` listening on the relevant port.
+   - Run the 0.19.0 binary, using the "wrong" configuration, with a clean data directory. The
+     `five-lines-first` file should be piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "right" configuration, and ensure that it reads the records from
+     the buffer and sends them to the HTTP sink.  This should be five records: all five from the run
+     using Vector 0.19.0.
+
+2. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
+   be read back from a version of Vector _with_ this change, even after additionally writing events
+   to the buffer that come from a version of Vector _with_ this change:
+   - Start `dummyhttp` listening on the relevant port.
+   - Run the 0.19.0 binary, using the "wrong" configuration, with a clean data directory. The
+     `five-lines-first` file should be piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "wrong" configuration. The `five-lines-second` file should be
+     piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "right" configuration, and ensure that it reads all the records
+     from the buffer and sends them to the HTTP sink.  This should be ten records: all five from
+     `five-lines-first`, and all five from `five-lines-second`.

--- a/issues/11072/test-results.md
+++ b/issues/11072/test-results.md
@@ -1,0 +1,142 @@
+# Test Results
+
+## Test 1
+
+```shell
+toby@consigliere:~/src/vector/testing/github-11072$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-11072$ ls -l /tmp/vector/github-11072/
+total 0
+toby@consigliere:~/src/vector/testing/github-11072$ cat five-lines-first | timeout 5s ./vector-v0.19.0 --config config-wrong-http.toml
+2022-02-25T01:37:26.452783Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-02-25T01:37:26.452827Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-02-25T01:37:26.453530Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-02-25T01:37:26.485638Z  INFO vector::topology::running: Running healthchecks.
+2022-02-25T01:37:26.485669Z  INFO vector::topology::running: Starting source. key=stdin
+2022-02-25T01:37:26.485699Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-02-25T01:37:26.485693Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-02-25T01:37:26.485727Z  INFO vector: Vector has started. debug="false" version="0.19.0" arch="x86_64" build_id="da60b55 2021-12-28"
+2022-02-25T01:37:26.485738Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-02-25T01:37:26.485878Z  INFO vector::shutdown: All sources have finished.
+2022-02-25T01:37:26.485883Z  INFO vector: Vector has stopped.
+2022-02-25T01:37:26.485887Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-02-25T01:37:26.486866Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-02-25T01:37:27.487708Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:37:28.489158Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:37:29.490469Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:37:31.445678Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-11072$ LOG=debug timeout 5s ./vector-pr --config config-right-http.toml
+2022-02-25T01:37:42.964509Z  INFO vector::app: Log level is enabled. level="debug"
+2022-02-25T01:37:42.964543Z  INFO vector::app: Loading configs. paths=["config-right-http.toml"]
+2022-02-25T01:37:42.965087Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-02-25T01:37:42.982001Z DEBUG vector_buffers::variants::disk_v1: Read 5 key(s) from database, with 585 bytes total, comprising 5 events total. first_key=Some(0) last_key=Some(4)
+2022-02-25T01:37:42.997579Z  INFO vector::topology::running: Running healthchecks.
+2022-02-25T01:37:42.997604Z  INFO vector::topology::running: Starting source. key=stdin
+2022-02-25T01:37:42.997625Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-02-25T01:37:42.997622Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-02-25T01:37:42.997648Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-02-25T01:37:47.959025Z  INFO vector: Vector has stopped.
+2022-02-25T01:37:47.959100Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+toby@consigliere:~/src/vector/testing/github-11072$
+
+### Output from `dummyhttp`, listening on port 7777:
+
+┌─Incoming request
+│ POST /foo HTTP/1.1
+│ Accept-Encoding: identity
+│ Content-Length: 635
+│ Content-Type: application/x-ndjson
+│ Host: localhost:7777
+│ User-Agent: Vector/0.21.0 (x86_64-unknown-linux-gnu)
+│ Body:
+│ {"host":"consigliere","message":"ONE line one, woohoo","source_type":"stdin","timestamp":"2022-02-25T01:37:26.485844093Z"}
+│ {"host":"consigliere","message":"ONE line two, yippeee","source_type":"stdin","timestamp":"2022-02-25T01:37:26.485859923Z"}
+│ {"host":"consigliere","message":"ONE line three, oh my","source_type":"stdin","timestamp":"2022-02-25T01:37:26.485863163Z"}
+│ {"host":"consigliere","message":"ONE line four, woooooow","source_type":"stdin","timestamp":"2022-02-25T01:37:26.485866083Z"}
+│ {"host":"consigliere","message":"ONE live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-02-25T01:37:26.485869063Z"}
+┌─Outgoing response
+│ HTTP/1.1 200 OK
+│ Body:
+│ dummyhttp
+```
+
+## Test 2
+
+```shell
+toby@consigliere:~/src/vector/testing/github-11072$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-11072$ ls -l /tmp/vector/github-11072/
+total 0
+toby@consigliere:~/src/vector/testing/github-11072$ cat five-lines-first | timeout 5s ./vector-v0.19.0 --config config-wrong-http.toml
+2022-02-25T01:41:16.856753Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-02-25T01:41:16.856794Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-02-25T01:41:16.857483Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-02-25T01:41:16.890151Z  INFO vector::topology::running: Running healthchecks.
+2022-02-25T01:41:16.890179Z  INFO vector::topology::running: Starting source. key=stdin
+2022-02-25T01:41:16.890220Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-02-25T01:41:16.890217Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-02-25T01:41:16.890255Z  INFO vector: Vector has started. debug="false" version="0.19.0" arch="x86_64" build_id="da60b55 2021-12-28"
+2022-02-25T01:41:16.890266Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-02-25T01:41:16.890384Z  INFO vector::shutdown: All sources have finished.
+2022-02-25T01:41:16.890388Z  INFO vector: Vector has stopped.
+2022-02-25T01:41:16.890389Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-02-25T01:41:16.891394Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-02-25T01:41:17.893338Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:18.894137Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:19.895376Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:21.849652Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-11072$ cat five-lines-second | timeout 5s ./vector-pr --config config-wrong-http.toml
+2022-02-25T01:41:44.759260Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info"
+2022-02-25T01:41:44.759298Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-02-25T01:41:44.759847Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-02-25T01:41:44.792206Z  INFO vector::topology::running: Running healthchecks.
+2022-02-25T01:41:44.792230Z  INFO vector::topology::running: Starting source. key=stdin
+2022-02-25T01:41:44.792237Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-02-25T01:41:44.792249Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-02-25T01:41:44.792277Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-02-25T01:41:44.792330Z  INFO vector::shutdown: All sources have finished.
+2022-02-25T01:41:44.792334Z  INFO vector: Vector has stopped.
+2022-02-25T01:41:44.792338Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-02-25T01:41:44.793363Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-02-25T01:41:45.794217Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:46.794700Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:47.796118Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+2022-02-25T01:41:49.753199Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-11072$ LOG=debug timeout 5s ./vector-pr --config config-right-http.toml
+2022-02-25T01:42:58.778637Z  INFO vector::app: Log level is enabled. level="debug"
+2022-02-25T01:42:58.778672Z  INFO vector::app: Loading configs. paths=["config-right-http.toml"]
+2022-02-25T01:42:58.779206Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-02-25T01:42:58.796518Z DEBUG vector_buffers::variants::disk_v1: Read 10 key(s) from database, with 1181 bytes total, comprising 10 events total. first_key=Some(0) last_key=Some(9)
+2022-02-25T01:42:58.812028Z  INFO vector::topology::running: Running healthchecks.
+2022-02-25T01:42:58.812050Z  INFO vector::topology::running: Starting source. key=stdin
+2022-02-25T01:42:58.812059Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-02-25T01:42:58.812070Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-02-25T01:42:58.812095Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-02-25T01:43:03.772068Z  INFO vector: Vector has stopped.
+2022-02-25T01:43:03.772144Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-02-25T01:43:03.773225Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-11072$
+
+### Output from `dummyhttp`, listening on port 7777:
+
+┌─Incoming request
+│ POST /foo HTTP/1.1
+│ Accept-Encoding: identity
+│ Content-Length: 1270
+│ Content-Type: application/x-ndjson
+│ Host: localhost:7777
+│ User-Agent: Vector/0.21.0 (x86_64-unknown-linux-gnu)
+│ Body:
+│ {"host":"consigliere","message":"ONE line one, woohoo","source_type":"stdin","timestamp":"2022-02-25T01:41:16.890350232Z"}
+│ {"host":"consigliere","message":"ONE line two, yippeee","source_type":"stdin","timestamp":"2022-02-25T01:41:16.890361362Z"}
+│ {"host":"consigliere","message":"ONE line three, oh my","source_type":"stdin","timestamp":"2022-02-25T01:41:16.890364482Z"}
+│ {"host":"consigliere","message":"ONE line four, woooooow","source_type":"stdin","timestamp":"2022-02-25T01:41:16.890367362Z"}
+│ {"host":"consigliere","message":"ONE live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-02-25T01:41:16.890370252Z"}
+│ {"host":"consigliere","message":"TWO line one, woohoo","source_type":"stdin","timestamp":"2022-02-25T01:41:44.792297540Z"}
+│ {"host":"consigliere","message":"TWO line two, yippeee","source_type":"stdin","timestamp":"2022-02-25T01:41:44.792307870Z"}
+│ {"host":"consigliere","message":"TWO line three, oh my","source_type":"stdin","timestamp":"2022-02-25T01:41:44.792312550Z"}
+│ {"host":"consigliere","message":"TWO line four, woooooow","source_type":"stdin","timestamp":"2022-02-25T01:41:44.792315949Z"}
+│ {"host":"consigliere","message":"TWO live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-02-25T01:41:44.792319309Z"}
+┌─Outgoing response
+│ HTTP/1.1 200 OK
+│ Body:
+│ dummyhttp
+```

--- a/issues/12069/config-right-http.toml
+++ b/issues/12069/config-right-http.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-12069"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7777/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/12069/config-wrong-http-big-buffer.toml
+++ b/issues/12069/config-wrong-http-big-buffer.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-12069"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7778/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 1000000000 # Roughly 1GB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/12069/config-wrong-http-disk-v2.toml
+++ b/issues/12069/config-wrong-http-disk-v2.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-12069"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7778/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk_v2"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/12069/config-wrong-http.toml
+++ b/issues/12069/config-wrong-http.toml
@@ -1,0 +1,18 @@
+data_dir = "/tmp/vector/github-12069"
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.http_tarpit]
+type = "http"
+inputs = ["stdin"]
+uri = "http://localhost:7778/foo"
+framing.method = "newline_delimited"
+encoding.codec = "json"
+
+[sinks.http_tarpit.buffer]
+type = "disk"
+max_size = 10000000 # Roughly 10MB.
+
+[sinks.http_tarpit.request]
+timeout_secs = 3600 # Plenty of time to make sure we can verify behavior.

--- a/issues/12069/create-clean-data-directories.sh
+++ b/issues/12069/create-clean-data-directories.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/vector/github-12069
+mkdir -p /tmp/vector/github-12069

--- a/issues/12069/five-lines-first
+++ b/issues/12069/five-lines-first
@@ -1,0 +1,5 @@
+ONE line one, woohoo
+ONE line two, yippeee
+ONE line three, oh my
+ONE line four, woooooow
+ONE live five, phew, that was a lot

--- a/issues/12069/five-lines-second
+++ b/issues/12069/five-lines-second
@@ -1,0 +1,5 @@
+TWO line one, woohoo
+TWO line two, yippeee
+TWO line three, oh my
+TWO line four, woooooow
+TWO live five, phew, that was a lot

--- a/issues/12069/get-and-build-vector-binaries.sh
+++ b/issues/12069/get-and-build-vector-binaries.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+curl -q -o vector-v0.20.0.tar.gz -L https://github.com/vectordotdev/vector/releases/download/v0.20.0/vector-0.20.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf vector-v0.20.0.tar.gz
+mv vector-x86_64-unknown-linux-gnu/bin/vector vector-v0.20.0
+rm -rf vector-x86_64-unknown-linux-gnu
+rm -f vector-v0.20.0.tar.gz
+
+pushd ../..
+cargo clean && cargo build --release --no-default-features --features sources-stdin,sinks-http
+popd || exit
+cp ../../target/release/vector vector-pr

--- a/issues/12069/steps.md
+++ b/issues/12069/steps.md
@@ -1,0 +1,81 @@
+# Testing Plan - automatically migrate disk v1 buffers to disk v2 (#12069)
+
+## Context
+
+As this PR introduces the change that moves the default `disk` buffer implementation from disk v1 to
+disk v2, we similarly add the logic to automatically migrate users' disk buffers from v1 to v2 when
+Vector starts.
+
+We do so to ensure that users do not upgrade Vector and have their old buffers fall by the wayside
+unbeknownst to them, as it is likely they may unintentionally upgrade such that they do not see any
+warning/error logs that we emit to indicate that they must first drain their old buffer before
+upgrading, and so on.
+
+Additionally, we did not change the on-disk format for `disk_v2` between 0.20.0 and now, so we
+should also be able to create a `disk_v2` buffer with 0.20.0 and continue using it as a `disk`
+buffer with a binary built from this PR.
+
+## Plan
+
+Start by grabbing a Vector binary for 0.20.0, and build one from the PR branch.  We'll use a simple
+configuration that will read records from stdin and attempt to send them to an HTTP sink.
+
+For the HTTP sink, we'll have one configuration that uses an invalid port and another, an identical
+version, which has the correct port. Since Vector will retry "connection refused" errors, and retry
+them infinitely, the messages will never be acknowledged, which ensures they remain in the buffer.
+For the purposes of verifying that the same data that went in is still present after migrating the
+disk v1 buffer, etc, we can use `dummyhttp` (a Rust project for serving up a simplistic HTTP
+endpoint that can be configured to respond a certain way) to listen on the port and inspect the HTTP
+request made by the sink.
+
+For generating logs so we can fill up our disk buffers to their limit, we'll use [`flog`][flog]
+which is a handy tool for generating fake logs, and a lot of them very quickly.
+
+## Test Case(s)
+
+1. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
+   be read back after being migrated:
+   - Start `dummyhttp` listening on the relevant port.
+   - Run the 0.20.0 binary, using the "wrong" configuration, with a clean data directory. The
+     `five-lines-first` file should be piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "wrong" configuration. The `five-lines-second` file should be
+     piped to STDIN.
+   - Observe that the old buffer has been migrated, and that five records have been migrated: the
+     entries from `five-lines-first`.
+   - Stop Vector.
+   - Run the PR binary, using the "right" configuration, and ensure that it reads the records from
+     the buffer and sends them to the HTTP sink. The `five-lines-second` file should be piped to
+     STDIN.
+
+     Overall, there should be fifteen records: all five from the run using Vector 0.20.0, five from
+     the run of the PR binary with the wrong configuration, and five from this run.
+
+2. Ensure that records written to a v2 disk buffer from a version of Vector without this change can
+   be read back after being migrated:
+   - Start `dummyhttp` listening on the relevant port.
+   - Run the 0.20.0 binary, using the "wrong disk v2" configuration, with a clean data directory.
+     The `five-lines-first` file should be piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "wrong" configuration. The `five-lines-second` file should be
+     piped to STDIN.
+   - Stop Vector.
+   - Run the PR binary, using the "right" configuration, and ensure that it reads the records from
+     the buffer and sends them to the HTTP sink. The `five-lines-second` file should be piped to
+     STDIN.
+
+     Overall, there should be fifteen records: all five from the run using Vector 0.20.0, five from
+     the run of the PR binary with the wrong configuration, and five from this run.
+
+3. Ensure that records written to a v1 disk buffer from a version of Vector without this change can
+   be migrated over when the new v2 buffer ends up exceeding the configured maximum buffer size:
+   - Run the 0.20.0 binary, using the "wrong big buffer" configuration, with a clean data directory.
+     `flog` should be piped to STDIN.
+   - Stop Vector once the maximum buffer size has been reached.
+   - Observe that the old buffer data directory is the only one that exists.
+   - Run the PR binary, using the "wrong big buffer" configuration. Do not feed any input to STDIN.
+   - Vector should immediately exit after reporting that the old buffer has been migrated.
+   - Observe that the old buffer directory is now gone, and the new one should exist.  Likewise, the
+     new one should be the same size or larger than the old one.
+
+[flog]: https://github.com/mingrammer/flog

--- a/issues/12069/test-results.md
+++ b/issues/12069/test-results.md
@@ -1,0 +1,240 @@
+# Test Results
+
+## Test 1
+
+```shell
+toby@consigliere:~/src/vector/testing/github-12069$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069/
+total 0
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-first | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-v0.20.0 -c ./config-wrong-http.toml
+2022-04-06T05:04:13.849578Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T05:04:13.849653Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-04-06T05:04:13.850709Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T05:04:13.878010Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T05:04:13.878042Z  INFO vector::topology::running: Starting source. key=stdin
+2022-04-06T05:04:13.878062Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-04-06T05:04:13.878061Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T05:04:13.878090Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="2a706a3 2022-02-11"
+2022-04-06T05:04:13.878100Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-04-06T05:04:13.878254Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T05:04:13.878259Z  INFO vector: Vector has stopped.
+2022-04-06T05:04:13.878295Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T05:04:13.879186Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-04-06T05:04:14.881161Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+...
+2022-04-06T05:04:16.884213Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T05:04:17.153507Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069/
+total 4
+drwxr-xr-x 2 toby toby 4096 Apr  6 01:04 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-second | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-pr -c ./config-wrong-http.toml
+2022-04-06T05:04:24.925006Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T05:04:24.925046Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-04-06T05:04:24.925725Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T05:04:24.954258Z  INFO vector_buffers::variants::disk_v2::v1_migration: Detected old `disk_v1`-based buffer for the `http_tarpit` sink. Automatically migrating to `disk_v2`.
+2022-04-06T05:04:24.954512Z  INFO vector_buffers::variants::disk_v2::v1_migration: Migrated 5 records in disk buffer for `http_tarpit` sink. Old disk buffer at '/tmp/vector/github-12069/http_tarpit_id' has been deleted, and the new disk buffer has been created at '/tmp/vector/github-12069/buffer/v2/http_tarpit'.
+2022-04-06T05:04:24.965194Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T05:04:24.965227Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T05:04:24.965266Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-04-06T05:04:24.965360Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T05:04:24.965366Z  INFO vector: Vector has stopped.
+2022-04-06T05:04:24.965390Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T05:04:24.966574Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-04-06T05:04:25.967353Z ERROR sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}:http: vector::internal_events::http_client: HTTP error. error=error trying to connect: tcp connect error: Connection refused (os error 111) error_type="request_failed" stage="processing"
+...
+2022-04-06T05:04:27.970443Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T05:04:28.341582Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069/
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 01:04 buffer
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-second | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-pr -c ./config-right-http.toml
+2022-04-06T05:04:49.046963Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T05:04:49.047005Z  INFO vector::app: Loading configs. paths=["config-right-http.toml"]
+2022-04-06T05:04:49.047691Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T05:04:49.063511Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T05:04:49.063545Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T05:04:49.063615Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-04-06T05:04:49.063676Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T05:04:49.063686Z  INFO vector: Vector has stopped.
+2022-04-06T05:04:49.063698Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T05:04:49.064697Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069/
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 01:04 buffer
+toby@consigliere:~/src/vector/testing/github-12069$
+
+### Output from `dummyhttp`, listening on port 7777:
+
+┌─Incoming request
+│ POST /foo HTTP/1.1
+│ Accept-Encoding: identity
+│ Content-Length: 1904
+│ Content-Type: application/x-ndjson
+│ Host: localhost:7777
+│ User-Agent: Vector/0.21.0 (x86_64-unknown-linux-gnu)
+│ Body:
+│ {"host":"consigliere","message":"ONE line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T05:04:13.878220775Z"}
+│ {"host":"consigliere","message":"ONE line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T05:04:13.878232125Z"}
+│ {"host":"consigliere","message":"ONE line three, oh my","source_type":"stdin","timestamp":"2022-04-06T05:04:13.878235815Z"}
+│ {"host":"consigliere","message":"ONE line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T05:04:13.878239495Z"}
+│ {"host":"consigliere","message":"ONE live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T05:04:13.878243155Z"}
+│ {"host":"consigliere","message":"TWO line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T05:04:24.965330623Z"}
+│ {"host":"consigliere","message":"TWO line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T05:04:24.965339593Z"}
+│ {"host":"consigliere","message":"TWO line three, oh my","source_type":"stdin","timestamp":"2022-04-06T05:04:24.965342863Z"}
+│ {"host":"consigliere","message":"TWO line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T05:04:24.965347233Z"}
+│ {"host":"consigliere","message":"TWO live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T05:04:24.965350343Z"}
+│ {"host":"consigliere","message":"TWO line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T05:04:49.063643366Z"}
+│ {"host":"consigliere","message":"TWO line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T05:04:49.063651736Z"}
+│ {"host":"consigliere","message":"TWO line three, oh my","source_type":"stdin","timestamp":"2022-04-06T05:04:49.063655096Z"}
+│ {"host":"consigliere","message":"TWO line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T05:04:49.063659046Z"}
+│ {"host":"consigliere","message":"TWO live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T05:04:49.063662266Z"}
+┌─Outgoing response
+│ HTTP/1.1 200 OK
+│ Body:
+│ dummyhttp
+```
+
+## Test 2
+
+```shell
+toby@consigliere:~/src/vector/testing/github-12069$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 0
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-first | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-v0.20.0 -c ./config-wrong-http-disk-v2.toml
+2022-04-06T14:45:58.018346Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T14:45:58.018397Z  INFO vector::app: Loading configs. paths=["config-wrong-http-disk-v2.toml"]
+2022-04-06T14:45:58.019085Z  WARN vector_buffers::config: !!!! The `disk_v2` buffer type is not yet stable.  Data loss may be encountered. !!!!
+2022-04-06T14:45:58.019150Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T14:45:58.040008Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T14:45:58.040048Z  INFO vector::topology::running: Starting source. key=stdin
+2022-04-06T14:45:58.040045Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T14:45:58.040065Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-04-06T14:45:58.040089Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="2a706a3 2022-02-11"
+2022-04-06T14:45:58.040097Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-04-06T14:45:58.040231Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T14:45:58.040235Z  INFO vector: Vector has stopped.
+2022-04-06T14:45:58.040260Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T14:45:58.041205Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-04-06T14:45:59.041836Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+...
+2022-04-06T14:46:01.044682Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T14:46:01.168349Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 10:45 buffer
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-second | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-pr -c ./config-wrong-http.toml
+2022-04-06T14:46:10.662767Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T14:46:10.662807Z  INFO vector::app: Loading configs. paths=["config-wrong-http.toml"]
+2022-04-06T14:46:10.663483Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T14:46:10.682030Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T14:46:10.682055Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T14:46:10.682089Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-04-06T14:46:10.682162Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T14:46:10.682168Z  INFO vector: Vector has stopped.
+2022-04-06T14:46:10.682186Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T14:46:10.683351Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+2022-04-06T14:46:11.683874Z ERROR sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}:http: vector::internal_events::http_client: HTTP error. error=error trying to connect: tcp connect error: Connection refused (os error 111) error_type="request_failed" stage="processing"
+...
+2022-04-06T14:46:13.686843Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T14:46:13.998989Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 10:45 buffer
+toby@consigliere:~/src/vector/testing/github-12069$ cat five-lines-second | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-pr -c ./config-right-http.toml
+2022-04-06T14:46:19.954798Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T14:46:19.954863Z  INFO vector::app: Loading configs. paths=["config-right-http.toml"]
+2022-04-06T14:46:19.955816Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T14:46:19.977729Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T14:46:19.977779Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T14:46:19.977845Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-04-06T14:46:19.977909Z  INFO vector::shutdown: All sources have finished.
+2022-04-06T14:46:19.977921Z  INFO vector: Vector has stopped.
+2022-04-06T14:46:19.977934Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T14:46:19.978975Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 10:45 buffer
+toby@consigliere:~/src/vector/testing/github-12069$
+
+### Output from `dummyhttp`, listening on port 7777:
+
+┌─Incoming request
+│ POST /foo HTTP/1.1
+│ Accept-Encoding: identity
+│ Content-Length: 1904
+│ Content-Type: application/x-ndjson
+│ Host: localhost:7777
+│ User-Agent: Vector/0.21.0 (x86_64-unknown-linux-gnu)
+│ Body:
+│ {"host":"consigliere","message":"ONE line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T14:45:58.040195072Z"}
+│ {"host":"consigliere","message":"ONE line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T14:45:58.040210202Z"}
+│ {"host":"consigliere","message":"ONE line three, oh my","source_type":"stdin","timestamp":"2022-04-06T14:45:58.040213862Z"}
+│ {"host":"consigliere","message":"ONE line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T14:45:58.040217562Z"}
+│ {"host":"consigliere","message":"ONE live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T14:45:58.040221152Z"}
+│ {"host":"consigliere","message":"TWO line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T14:46:10.682136661Z"}
+│ {"host":"consigliere","message":"TWO line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T14:46:10.682144171Z"}
+│ {"host":"consigliere","message":"TWO line three, oh my","source_type":"stdin","timestamp":"2022-04-06T14:46:10.682146871Z"}
+│ {"host":"consigliere","message":"TWO line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T14:46:10.682150341Z"}
+│ {"host":"consigliere","message":"TWO live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T14:46:10.682153241Z"}
+│ {"host":"consigliere","message":"TWO line one, woohoo","source_type":"stdin","timestamp":"2022-04-06T14:46:19.977879319Z"}
+│ {"host":"consigliere","message":"TWO line two, yippeee","source_type":"stdin","timestamp":"2022-04-06T14:46:19.977887119Z"}
+│ {"host":"consigliere","message":"TWO line three, oh my","source_type":"stdin","timestamp":"2022-04-06T14:46:19.977889719Z"}
+│ {"host":"consigliere","message":"TWO line four, woooooow","source_type":"stdin","timestamp":"2022-04-06T14:46:19.977892039Z"}
+│ {"host":"consigliere","message":"TWO live five, phew, that was a lot","source_type":"stdin","timestamp":"2022-04-06T14:46:19.977895399Z"}
+┌─Outgoing response
+│ HTTP/1.1 200 OK
+│ Body:
+│ dummyhttp
+```
+
+## Test 3
+
+```shell
+toby@consigliere:~/src/vector/testing/github-12069$ ./create-clean-data-directories.sh
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 0
+toby@consigliere:~/src/vector/testing/github-12069$ ~/go/bin/flog -l | VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-v0.20.0 -c ./config-wrong-http-big-buffer.toml
+2022-04-06T17:40:40.693387Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T17:40:40.693437Z  INFO vector::app: Loading configs. paths=["config-wrong-http-big-buffer.toml"]
+2022-04-06T17:40:40.694227Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T17:40:40.728626Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T17:40:40.728662Z  INFO vector::topology::running: Starting source. key=stdin
+2022-04-06T17:40:40.728684Z  INFO vector::topology::running: Starting sink. key=http_tarpit
+2022-04-06T17:40:40.728681Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T17:40:40.728709Z  INFO vector: Vector has started. debug="false" version="0.20.0" arch="x86_64" build_id="2a706a3 2022-02-11"
+2022-04-06T17:40:40.728718Z  INFO vector::app: API is disabled, enable by setting `api.enabled` to `true` and use commands like `vector top`.
+2022-04-06T17:40:41.077849Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+...
+2022-04-06T17:41:01.103461Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T17:41:05.913348Z  INFO vector: Vector has stopped.
+2022-04-06T17:41:05.914492Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit, stdin" time_remaining="59 seconds left"
+^C2022-04-06T17:41:06.497154Z  INFO vector: Vector has quit.
+
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 12
+drwxr-xr-x 2 toby toby 12288 Apr  6 13:40 http_tarpit_id
+toby@consigliere:~/src/vector/testing/github-12069$ du -h /tmp/vector/github-12069/http_tarpit_id/
+929M    /tmp/vector/github-12069/http_tarpit_id/
+toby@consigliere:~/src/vector/testing/github-12069$ VECTOR_LOG="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info" ./vector-pr -c ./config-wrong-http-big-buffer.toml
+2022-04-06T17:41:52.772547Z  INFO vector::app: Log level is enabled. level="vector=info,codec=info,vrl=info,file_source=info,tower_limit=trace,rdkafka=info,buffers=info,kube=info,vector_buffers=info"
+2022-04-06T17:41:52.772588Z  INFO vector::app: Loading configs. paths=["config-wrong-http-big-buffer.toml"]
+2022-04-06T17:41:52.773258Z  INFO vector::sources::stdin: Capturing STDIN.
+2022-04-06T17:41:53.809795Z  INFO vector_buffers::variants::disk_v2::v1_migration: Detected old `disk_v1`-based buffer for the `http_tarpit` sink. Automatically migrating to `disk_v2`.
+2022-04-06T17:43:08.244317Z  INFO vector_buffers::variants::disk_v2::v1_migration: Migrated 4560522 records in disk buffer for `http_tarpit` sink. Old disk buffer at '/tmp/vector/github-12069/http_tarpit_id' has been deleted, and the new disk buffer has been created at '/tmp/vector/github-12069/buffer/v2/http_tarpit'.
+2022-04-06T17:43:08.256533Z  INFO vector::topology::running: Running healthchecks.
+2022-04-06T17:43:08.256573Z  INFO vector::topology::builder: Healthcheck: Passed.
+2022-04-06T17:43:08.256616Z  INFO vector: Vector has started. debug="false" version="0.21.0" arch="x86_64" build_id="none"
+2022-04-06T17:43:08.523110Z ERROR sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}:http: vector::internal_events::http_client: HTTP error. error=error trying to connect: tcp connect error: Connection refused (os error 111) error_type="request_failed" stage="processing"
+...
+2022-04-06T17:43:15.537528Z  WARN sink{component_kind="sink" component_id=http_tarpit component_type=http component_name=http_tarpit}:request{request_id=0}: vector::sinks::util::retries: Retrying after error. error=Failed to make HTTP(S) request: error trying to connect: tcp connect error: Connection refused (os error 111)
+^C2022-04-06T17:43:17.057250Z  INFO vector: Vector has stopped.
+2022-04-06T17:43:17.057303Z  INFO source{component_kind="source" component_id=stdin component_type=stdin component_name=stdin}: vector::sources::stdin: Finished sending.
+2022-04-06T17:43:17.058370Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="http_tarpit" time_remaining="59 seconds left"
+^C2022-04-06T17:43:18.428485Z  INFO vector: Vector has quit.
+toby@consigliere:~/src/vector/testing/github-12069$ ls -l /tmp/vector/github-12069
+total 4
+drwxrwxr-x 3 toby toby 4096 Apr  6 13:41 buffer
+toby@consigliere:~/src/vector/testing/github-12069$ du -h /tmp/vector/github-12069/buffer/v2/http_tarpit
+1.1G    /tmp/vector/github-12069/buffer/v2/http_tarpit
+toby@consigliere:~/src/vector/testing/github-12069$
+```

--- a/issues/20228/config.toml
+++ b/issues/20228/config.toml
@@ -1,0 +1,46 @@
+
+[[tests]]
+name = "Test log_to_metric conversion of sets"
+
+# The inputs for the test
+[[tests.inputs]]
+insert_at = "parse_json"
+type = "log"
+
+[tests.inputs.log_fields]
+message = '{"name": "sample.set.metric", "tags": {"host": "my-host", "region": "us-west"}, "kind": "incremental", "values": [1, 2, 3, 4, 5]}'
+
+[[tests.outputs]]
+extract_from = "convert_metrics"
+
+# We just validate that the values are the same
+[[tests.outputs.conditions]]
+type = "vrl"
+source = '''
+assert!(.name == "sample.set.metric")
+assert!(.tags.host == "my-host")
+assert!(.tags.region == "us-west")
+assert!(.kind == "incremental")
+'''
+
+[sources.stdin]
+type = "stdin"
+
+[sinks.stdout]
+inputs = ["convert_metrics"]
+type = "console"
+encoding.codec = "json"
+
+[transforms.parse_json]
+inputs = ["stdin"]
+type = "remap"
+source = '''
+. = parse_json!(.message)
+'''
+
+[transforms.convert_metrics]
+inputs = ["parse_json"]
+type = "log_to_metric"
+all_metrics = true
+metrics = []
+


### PR DESCRIPTION
## Summary

Moves manual buffer issue reproduction configs from `vectordotdev/vector` into this repo under `issues/<number>/`, following the existing naming convention.

Issues covered (all buffer-related, from ~2022-2023):
- 10430 — disk buffer data directory migration
- 10895 — buffer testing/shoring up
- 11039 — disk buffer versioning/schema evolution
- 11072 — HTTP buffer behavior comparison
- 12069 — HTTP buffer behavior comparison (big buffer, disk v2)
- 20228 — misc buffer repro

Each directory contains the original Vector config(s), shell scripts for setting up test data and fetching old binaries, and `steps.md`/`test-results.md` documentation.